### PR TITLE
Let actors be inside hollow surface regions

### DIFF
--- a/src/subvolume.c
+++ b/src/subvolume.c
@@ -436,10 +436,7 @@ void buildSubvolArray(const uint32_t numSub,
 							// Is it possible for child to block subvolumes of parent?
 							if((regionArray[i].spec.type != REGION_NORMAL
 								&& regionArray[regionArray[i].childrenID[j]].spec.type
-								== REGION_NORMAL)
-								|| (regionArray[i].plane == PLANE_3D
-								&& regionArray[regionArray[i].childrenID[j]].plane
-								!= PLANE_3D))
+								== REGION_NORMAL))
 							{
 								continue; // This child cannot interfere with the
 										  // subvolumes of the parent
@@ -459,7 +456,7 @@ void buildSubvolArray(const uint32_t numSub,
 									regionArray[regionArray[i].childrenID[j]].spec.shape,
 									regionArray[regionArray[i].childrenID[j]].boundary, 0.))
 								{
-									// subvolume is entirely within spherical child
+									// subvolume is entirely within child
 									bRealSub = false;
 									subID[i][cur1][cur2][cur3] = UINT32_MAX;
 									break;


### PR DESCRIPTION
- enabled placement of actors inside hollow surface regions
- prevent parent/child regions from being neighbors if one of them is a
  surface pointed in the opposite direction
- added check on child region that is an inner surface to ensure that
  its parent is an outer surface that covers it fully
- improved membrane transitions to allow transition through cases when
  region on other side of membrane was not a neighbor of the starting
  region. Only works if region on other side of membrane is a neighbor of
  the membrane region (i.e., not in nested grandparent cases)
- wrote code to potentially allow a 3D surface region that is a 3D shape
  to have a 3D surface child. This is not enabled due to issues with
  requiring transitions between regions that are not neighbors.
