### PR TITLE
Improving integration of surface reactions

### DIFF
--- a/src/chem_rxn.h
+++ b/src/chem_rxn.h
@@ -53,7 +53,14 @@ struct chem_rxn_struct { // Used to define a single chemical reaction
 	// Base reaction rate k (units depends on order of reaction)
 	double k;
 	
+	// Is the reaction a surface reaction?
+	// This will affect where a reaction will take place by default,
+	// as indicated by bEverywhere
+	bool bSurface;
+	
 	// Can the reaction take place anywhere by default?
+	// Actual regions will depend on value of bSurface and whether a given
+	// region is a normal region or a surface
 	bool bEverywhere;
 	
 	// Number of regions that are exceptions to the location default
@@ -65,6 +72,12 @@ struct chem_rxn_struct { // Used to define a single chemical reaction
 	
 	// TODO: Add parameters for reactions that take place across multiple
 	// regions (i.e., surface interactions)
+	
+	// Type of surface reaction.
+	// Affects how the reaction probability is calculated
+	// Default is RXN_NORMAL, which determines reaction probability from
+	// reaction rate as if it were a solution reaction
+	short surfRxnType;
 };
 
 //
@@ -79,7 +92,8 @@ void initializeRegionChemRxn(const short NUM_REGIONS,
 	struct region regionArray[],
 	const unsigned short NUM_MOL_TYPES,
 	const unsigned short MAX_RXNS,
-	const struct chem_rxn_struct chem_rxn[]);
+	const struct chem_rxn_struct chem_rxn[],
+	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES]);
 
 void deleteRegionChemRxn(const short NUM_REGIONS,
 	const unsigned short NUM_MOL_TYPES,

--- a/src/global_param.h
+++ b/src/global_param.h
@@ -97,4 +97,11 @@
 // NOTE: Changes to list of names must be reflected in file_io.c
 #define CSK 0
 
+// 1st Order Surface reaction types
+// NOTE: Changes to list of names must be reflected in file_io.c
+#define RXN_NORMAL 0
+#define RXN_ABSORBING 1
+#define RXN_RECEPTOR 2
+#define RXN_MEMBRANE 3
+
 #endif // GLOBAL_PARAM_H

--- a/src/region.c
+++ b/src/region.c
@@ -227,7 +227,7 @@ void initializeRegionArray(struct region regionArray[],
 	
 	// Define chemical reaction network
 	initializeRegionChemRxn(NUM_REGIONS, regionArray,
-		NUM_MOL_TYPES, MAX_RXNS, chem_rxn);
+		NUM_MOL_TYPES, MAX_RXNS, chem_rxn, DIFF_COEF);
 }
 
 // Initialize region knowledge of the subvolumes that are adjacent to it


### PR DESCRIPTION
- added chemical reaction parameters to select type of reaction, in
  order to account for different ways of determining the reaction
  probability
- integrated changes with configuration file import code
- enabled first order reactions with infinite reaction rates
- limiting chemical reactions at membranes to only be membrane type
  reactions (i.e., first order)
- a molecule type cannot be a reactant for more than 1 surface
  (non-normal) reaction
- corrected memory allocation when a chemical reaction is not properly
  defined
