### PR TITLE
Fixed implementation of membrane transition reactions

### DIFF
--- a/src/file_io.h
+++ b/src/file_io.h
@@ -16,9 +16,10 @@
  * Revision LATEST_VERSION
  * - added bReleaseProduct to chemical reaction. Applies to surface reactions
  * - added chemical reaction properties to define coupled reversible reactions
- * - added chemical reaction properties to configure absorbing and desorbing reactions,
- * including how transition probabilities are calculated and where desorbed molecules
- * are placed.
+ * - added chemical reaction properties to configure absorbing, desorbing, and membrane
+ * reactions, including how transition probabilities are calculated and how
+ * desorbed molecules are placed. Membrane reactions must have no product molecules
+ * specified (product is always the same as the reactant)
  * - shortened string used to indicate how actor location is defined. This avoids
  * a MATLAB warning when loaded simulation configuration files
  *

--- a/src/global_param.h
+++ b/src/global_param.h
@@ -101,9 +101,8 @@
 #define RXN_ABSORBING 1
 #define RXN_DESORBING 2
 #define RXN_RECEPTOR 3
-#define RXN_MEMBRANE 4
-#define RXN_MEMBRANE_IN 5
-#define RXN_MEMBRANE_OUT 6
+#define RXN_MEMBRANE_IN 4
+#define RXN_MEMBRANE_OUT 5
 
 // Types of reaction probability calculations
 // NOTE: Changes to list of names must be reflected in file_io.c
@@ -115,8 +114,6 @@
 // NOTE: Changes to list of names must be reflected in file_io.c
 #define PROD_PLACEMENT_LEAVE 0 // Leave molecule next to surface
 #define PROD_PLACEMENT_FORCE 1 // Force diffusion away from surface
-#define PROD_PLACEMENT_IRREVERSIBLE 2 // Force diffusion away from surface based on unknown
-									  // desorption time
-#define PROD_PLACEMENT_STEADY_STATE 3 // Force diffuse based on steady-state values
+#define PROD_PLACEMENT_STEADY_STATE 2 // Force diffuse based on steady-state values
 
 #endif // GLOBAL_PARAM_H

--- a/src/micro_molecule.h
+++ b/src/micro_molecule.h
@@ -18,6 +18,8 @@
  * - updated first order reaction functions to account for surface reactions that
  * release products from the surface. This is done in a common function (for both old
  * and recent molecules). Placement of products depends on user configuration
+ * - fixed membrane transition reactions. They can be reversible and should not have
+ * product molecules explicitly defined.
  * - added calls to new functions to determine adsorption/desorption probabilities
  * for recent molecules
  * - corrected how molecules are locked to region boundary when they cross regions


### PR DESCRIPTION
- define separate "inner" and "outer" membrane reactions
- membrane transition probabilities based on Andrews' reversible
  adsorption paper
- removed the irreversible product placement type, since it's just a
  special case of steady state (depending on whether reaction was defined
  as reversible)
- membrane reaction product is always the same molecule type as the
  reactant
