### PR TITLE
Improvehybridtransitions

### DIFF
--- a/config/accord_config_sample_all_shapes_hybrid.txt
+++ b/config/accord_config_sample_all_shapes_hybrid.txt
@@ -8,9 +8,10 @@
 	The definition of the actors is a blend of absolute (defined by geometry) and
 	relative (defined by list of regions).
 	In this version, regions are a blend of mesoscopic and microscopic. This version
-	is measurably less accurate than the all-microscopic and all-mesoscopic versions, since
-	the microscopic time step has not been optimized and the current transition rules across
-	the hybrid interface are simplistic.",
+	is measurably less accurate than the all-microscopic and all-mesoscopic versions, due to
+	the limitations in accuracy across hybrid interfaces. Furthermore, the hybrid interfaces
+	here are particularly asymmetric with multiple close transitions between the 2 regimes.
+	A better example configuration with a hybrid interface is 'accord_config_sample_hybrid.txt'.",
 	"Output Filename": "accord_sample_all_shapes_hybrid",
 	"Warning Override": false,
 	"Simulation Control": {
@@ -18,7 +19,9 @@
 		"Final Simulation Time": 1,
 		"Global Microscopic Time Step": 1e-3,
 		"Random Number Seed": 1,
-		"Max Number of Progress Updates": 100
+		"Max Number of Progress Updates": 100,
+		"Small Subvolumes at Hybrid Interface?": true,
+		"Max Intrastep Micro to Meso Distance": 10e-6
 	},
 	"Chemical Properties": {
 		"Number of Molecule Types": 2,

--- a/config/accord_config_sample_hybrid.txt
+++ b/config/accord_config_sample_hybrid.txt
@@ -1,0 +1,124 @@
+{
+	"Notes": "Notes fields replace commenting, which is not standard in JSON.",
+	"Description": "This configuration is a simple hybrid environment, with 1 microscopic
+		region and 1 mesoscopic region. Both regions are rectangular boxes and they are
+		adjacent. There are 1000 molecules initialized uniformaly, so about one half
+		of the molecules should remain in each region over time.",
+	"Output Filename": "accord_sample_hybrid",
+	"Warning Override": false,
+	"Simulation Control": {
+		"Number of Repeats": 1,
+		"Final Simulation Time": 10,
+		"Global Microscopic Time Step": 1e-3,
+		"Random Number Seed": 1,
+		"Max Number of Progress Updates": 100,
+		"Small Subvolumes at Hybrid Interface?": true,
+		"Max Intrastep Micro to Meso Distance": 10e-6
+	},
+	"Chemical Properties": {
+		"Number of Molecule Types": 2,
+		"Diffusion Coefficients": [2e-9, 5e-11],
+		"Chemical Reaction Specification": []
+	},
+	"Environment":	{
+		"Number of Dimensions": 3,
+		"Subvolume Base Size": 1e-6,
+		"Region Specification": [
+			{
+				"Notes": "",
+				"Label": "Left",
+				"Parent Label": "",
+				"Shape": "Rectangular Box",
+				"Type": "Normal",
+				"Anchor X Coordinate": 0,
+				"Anchor Y Coordinate": 0,
+				"Anchor Z Coordinate": 0,
+				"Integer Subvolume Size": 5,
+				"Is Region Microscopic?": false,
+				"Number of Subvolumes Along X": 10,
+				"Number of Subvolumes Along Y": 10,
+				"Number of Subvolumes Along Z": 10
+			},
+			{
+				"Notes": "",
+				"Label": "Right",
+				"Parent Label": "",
+				"Shape": "Rectangular Box",
+				"Type": "Normal",
+				"Anchor X Coordinate": 50e-6,
+				"Anchor Y Coordinate": 0e-6,
+				"Anchor Z Coordinate": 0e-6,
+				"Integer Subvolume Size": 5,
+				"Is Region Microscopic?": true,
+				"Number of Subvolumes Along X": 10,
+				"Number of Subvolumes Along Y": 10,
+				"Number of Subvolumes Along Z": 10
+			}
+		],
+		"Actor Specification": [
+		{
+				"Notes": "Observer of whole system",
+				"Is Location Defined by Regions?": true,
+				"List of Regions Defining Location": ["Right", "Left"],
+				"Is Actor Active?": false,
+				"Start Time": 1e-10,
+				"Is There Max Number of Actions?": false,
+				"Is Actor Independent?": true,
+				"Action Interval": 0.1,
+				"Is Actor Activity Recorded?": true,
+				"Is Time Recorded with Activity?": false,
+				"Is Molecule Type Observed?": [true, false],
+				"Is Molecule Position Observed?": [false, false]
+		},
+		{
+				"Notes": "Observer of right",
+				"Is Location Defined by Regions?": true,
+				"List of Regions Defining Location": ["Right"],
+				"Is Actor Active?": false,
+				"Start Time": 1e-10,
+				"Is There Max Number of Actions?": false,
+				"Is Actor Independent?": true,
+				"Action Interval": 0.1,
+				"Is Actor Activity Recorded?": true,
+				"Is Time Recorded with Activity?": false,
+				"Is Molecule Type Observed?": [true, false],
+				"Is Molecule Position Observed?": [false, false]
+		},
+		{
+				"Notes": "Observer of left",
+				"Is Location Defined by Regions?": true,
+				"List of Regions Defining Location": ["Left"],
+				"Is Actor Active?": false,
+				"Start Time": 1e-10,
+				"Is There Max Number of Actions?": false,
+				"Is Actor Independent?": true,
+				"Action Interval": 0.1,
+				"Is Actor Activity Recorded?": true,
+				"Is Time Recorded with Activity?": false,
+				"Is Molecule Type Observed?": [true, false],
+				"Is Molecule Position Observed?": [false, false]
+		},
+		{
+				"Notes": "Transmitter 1. Releases 1 molecule per 10 cubic microns",
+				"Is Location Defined by Regions?": true,
+				"List of Regions Defining Location": ["Right", "Left"],
+				"Is Actor Active?": true,
+				"Start Time": 0,
+				"Is There Max Number of Actions?": false,
+				"Is Actor Independent?": true,
+				"Action Interval": 1000000,
+				"Is Actor Activity Recorded?": true,
+				"Random Number of Molecules?": false,
+				"Random Molecule Release Times?": false,
+				"Release Interval": 0,
+				"Slot Interval": 0,
+				"Bits Random?": true,
+				"Probability of Bit 1": 1,
+				"Modulation Scheme": "CSK",
+				"Modulation Bits": 1,
+				"Modulation Strength": 1000,
+				"Is Molecule Type Released?": [true, false]
+		}
+		]		
+	}
+}

--- a/src/actor.c
+++ b/src/actor.c
@@ -576,7 +576,7 @@ void initializeActorActivePassive(const short NUM_ACTORS,
 	int i; // loop index
 	short curActor, curActive, curPassive;
 	short curRegion, curInterRegion;
-	short curPassiveRecord, curActiveRecord;
+	short curPassiveRecord;
 	uint32_t curSub, curInterSub, gamma;
 	double curSubBound[6];
 	double curInterSubBound[6];
@@ -594,15 +594,9 @@ void initializeActorActivePassive(const short NUM_ACTORS,
 		}
 	}
 	
-	curActiveRecord = 0;
 	for(curActive = 0; curActive < NUM_ACTORS_ACTIVE; curActive++)
 	{
 		curActor = actorActiveArray[curActive].actorID;
-		
-		if (actorCommonArray[curActor].spec.bWrite)
-		{
-			actorPassiveArray[curActive].recordID = curActiveRecord++;
-		}
 		
 		actorActiveArray[curActive].cumFracActorInSub =
 			malloc(actorCommonArray[curActor].numRegion*sizeof(double *));

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -14,6 +14,12 @@
  * Revision history:
  *
  * Revision LATEST_VERSION
+ * - added option for user to select small subvolume or big subvolume assumption
+ * at hybrid interfaces. Only needed if there is at least 1 microscopic and 1
+ * mesoscopic region defined.
+ * - added option for user to choose maximum distance beyond which a micro to mesoscopic
+ * substep transition will not be considered (either initial or final point should be beyond
+ * this distance)
  * - made output of active actor data sequence a user option
  * - added option for user to define a constant active actor bit sequence
  * - added warnings for unnecessary active actor parameters depending on values
@@ -92,7 +98,9 @@ void loadConfig(const char * CONFIG_NAME,
 	int ch;
 	size_t temp; // Garbage variable for discarded file content length
 	int minSubDim = 0; // Minimum # of subvolumes along each dimension for a rectangular region
-	bool bNeedReleaseType;
+	bool bNeedReleaseType; // For surface reaction, does user need to specify what happens to products?
+	bool bHasMicro = false; // There is at least one microscopic region
+	bool bHasMeso = false; // There is at least one mesoscopic region
 	
 	// Construct full name of configuration file
 	nameLength = strlen(CONFIG_NAME);
@@ -992,6 +1000,12 @@ void loadConfig(const char * CONFIG_NAME,
 					cJSON_GetObjectItem(curObj, "Is Region Microscopic?")->valueint;
 			}
 			
+			// Track whether we need might need to consider hybrid interfaces
+			if(curSpec->subvol_spec[curArrayItem].bMicro)
+				bHasMicro = true;
+			else
+				bHasMeso = true;
+			
 			if(curSpec->subvol_spec[curArrayItem].shape == RECTANGLE)
 				minSubDim = 0;
 			else
@@ -1060,6 +1074,7 @@ void loadConfig(const char * CONFIG_NAME,
 		{
 			curSpec->subvol_spec[curArrayItem].sizeRect = 0;
 			curSpec->subvol_spec[curArrayItem].bMicro = true;
+			bHasMicro = true;
 			curSpec->subvol_spec[curArrayItem].numX = 1;
 			curSpec->subvol_spec[curArrayItem].numY = 1;
 			curSpec->subvol_spec[curArrayItem].numZ = 1;
@@ -1112,6 +1127,49 @@ void loadConfig(const char * CONFIG_NAME,
 		//	cJSON_GetObjectItem(curObj,
 		//	"Time Step")->valuedouble;
 	}
+	
+	// Check whether we might need a hybrid interface
+	if(bHasMeso && bHasMicro)
+	{
+		if(cJSON_bItemValid(simControl,"Small Subvolumes at Hybrid Interface?", cJSON_True))
+		{
+			curSpec->B_HYBRID_SMALL_SUB =
+				cJSON_GetObjectItem(simControl, "Small Subvolumes at Hybrid Interface?")->valueint;
+		} else
+		{ // Simulation does not have a valid Small Subvolumes at Hybrid Interface?
+			bWarn = true;
+			printf("WARNING %d: Simulation has at least 1 microscopic region and 1 mesoscopic region, but does not have a valid \"Small Subvolumes at Hybrid Interface?\". Assigning default value \"true\".\n", numWarn++);
+			curSpec->B_HYBRID_SMALL_SUB = true;
+		}
+		
+		if(cJSON_bItemValid(simControl,"Max Intrastep Micro to Meso Distance", cJSON_Number) &&
+			cJSON_GetObjectItem(simControl, "Max Intrastep Micro to Meso Distance")->valuedouble >= 0.)
+		{
+			curSpec->MAX_HYBRID_DIST =
+				cJSON_GetObjectItem(simControl, "Max Intrastep Micro to Meso Distance")->valuedouble;
+		} else
+		{ // Simulation does not have a valid Min Intrastep Micro to Meso Probability
+			bWarn = true;
+			printf("WARNING %d: Simulation has at least 1 microscopic region and 1 mesoscopic region, but does not have a valid \"Max Intrastep Micro to Meso Distance\". Assigning default value \"INFINITY\".\n", numWarn++);
+			curSpec->MAX_HYBRID_DIST = INFINITY;
+		}
+	} else
+	{
+		// Warn if any hybrid properties are defined
+		if(cJSON_bItemValid(simControl,
+			"Small Subvolumes at Hybrid Interface?", cJSON_True))
+		{
+			bWarn = true;
+			printf("WARNING %d: Simulation cannot have a hybrid interface, but \"Small Subvolumes at Hybrid Interface?\" was defined. Ignoring.\n", numWarn++);
+		}
+		if(cJSON_bItemValid(simControl,"Max Intrastep Micro to Meso Distance", cJSON_Number))
+		{
+			bWarn = true;
+			printf("WARNING %d: Simulation cannot have a hybrid interface, but \"Max Intrastep Micro to Meso Distance\" was defined. Ignoring.\n", numWarn++);
+		}
+	}
+	
+	// Load actor details
 	for(curArrayItem = 0;
 		curArrayItem < curSpec->NUM_ACTORS; curArrayItem++)
 	{			

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -1771,7 +1771,7 @@ void deleteConfig(struct simSpec3D curSpec)
 			{
 				if(curSpec.actorSpec[curActor].bReleaseMol != NULL)
 					free(curSpec.actorSpec[curActor].bReleaseMol);
-				if(curSpec.actorSpec[curActor].bRandBits
+				if(!curSpec.actorSpec[curActor].bRandBits
 					&& curSpec.actorSpec[curActor].bBits != NULL)
 					free(curSpec.actorSpec[curActor].bBits);
 			} else
@@ -2086,7 +2086,7 @@ void printTextEnd(FILE * out,
 		cJSON_AddNumberToObject(newActor, "ID",
 			actorActiveArray[curActor].actorID);
 		cJSON_AddNumberToObject(newActor, "MaxBitLength",
-			maxActiveBits[curActor]);
+			maxActiveBits[curActorRecord]);
 		cJSON_AddItemToArray(curArray, newActor);
 	}
 	

--- a/src/file_io.h
+++ b/src/file_io.h
@@ -14,6 +14,12 @@
  * Revision history:
  *
  * Revision LATEST_VERSION
+ * - added option for user to select small subvolume or big subvolume assumption
+ * at hybrid interfaces. Only needed if there is at least 1 microscopic and 1
+ * mesoscopic region defined.
+ * - added option for user to choose maximum distance beyond which a micro to mesoscopic
+ * substep transition will not be considered (either initial or final point should be beyond
+ * this distance)
  * - made output of active actor data sequence a user option
  * - added option for user to define a constant active actor bit sequence
  * - added warnings for unnecessary active actor parameters depending on values
@@ -99,6 +105,8 @@ struct simSpec3D {
 	double DT_MICRO;
 	uint32_t SEED;
 	unsigned int MAX_UPDATES;
+	bool B_HYBRID_SMALL_SUB;
+	double MAX_HYBRID_DIST;
 	
 	// Environment
 	double SUBVOL_BASE_SIZE;

--- a/src/micro_molecule.h
+++ b/src/micro_molecule.h
@@ -17,6 +17,8 @@
  * Revision LATEST_VERSION
  * - added check for molecules entering mesoscopic regime "during" a microscopic time step,
  * i.e., when molecule is in micro at start and end of diffusion step.
+ * - added function for placing molecules in microscopic regime when they come from the
+ * mesoscopic region
  * - modified random number generation. Now use PCG via a separate interface file.
  *
  * Revision v0.5.1 (2016-05-06)
@@ -128,6 +130,7 @@ void diffuseMolecules(const short NUM_REGIONS,
 	struct subvolume3D subvolArray[],
 	double sigma[NUM_REGIONS][NUM_MOL_TYPES],
 	const struct chem_rxn_struct chem_rxn[],
+	const double HYBRID_DIST_MAX,
 	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES]);
 
 void diffuseOneMolecule(ItemMol3D * molecule, double sigma);
@@ -144,7 +147,18 @@ bool bEnterMesoIndirect(const short NUM_REGIONS,
 	const double oldPoint[3],
 	const double newPoint[3],
 	uint32_t * newSub,
+	const double HYBRID_DIST_MAX,
 	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES]);
+
+// Place a molecule entering microscopic region from a mesoscopic subvolume
+void placeInMicroFromMeso(const unsigned short curRegion,
+	const unsigned short destRegion,
+	const struct region regionArray[],
+	const uint32_t curBoundSub,
+	const bool bSmallSub,
+	const unsigned short curMolType,
+	ListMolRecent3D * pRecentList,
+	const double DIFF_COEF);
 
 void rxnFirstOrder(const unsigned short NUM_REGIONS,
 	const unsigned short NUM_MOL_TYPES,

--- a/src/micro_molecule.h
+++ b/src/micro_molecule.h
@@ -15,6 +15,8 @@
  * Revision history:
  *
  * Revision LATEST_VERSION
+ * - added check for molecules entering mesoscopic regime "during" a microscopic time step,
+ * i.e., when molecule is in micro at start and end of diffusion step.
  * - modified random number generation. Now use PCG via a separate interface file.
  *
  * Revision v0.5.1 (2016-05-06)
@@ -131,6 +133,18 @@ void diffuseMolecules(const short NUM_REGIONS,
 void diffuseOneMolecule(ItemMol3D * molecule, double sigma);
 
 void diffuseOneMoleculeRecent(ItemMolRecent3D * molecule, double DIFF_COEF);
+
+// Did molecule enter mesoscopic region while diffusing?
+bool bEnterMesoIndirect(const short NUM_REGIONS,
+	const unsigned short NUM_MOL_TYPES,
+	const struct region regionArray[],
+	const short curType,
+	const short curRegion,
+	short * mesoRegion,
+	const double oldPoint[3],
+	const double newPoint[3],
+	uint32_t * newSub,
+	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES]);
 
 void rxnFirstOrder(const unsigned short NUM_REGIONS,
 	const unsigned short NUM_MOL_TYPES,

--- a/src/rand_accord.c
+++ b/src/rand_accord.c
@@ -36,6 +36,18 @@ double generateUniform()
 	return (double) pcg32_random()/UINT32_MAX;
 }
 
+// Return a triangular random number
+// Value will be in range [0,2]
+double generateTriangular()
+{
+	double uniRV = (double) pcg32_random()/UINT32_MAX;
+	
+	if(uniRV < 0.5)
+		return sqrt(2*uniRV);
+	else
+		return (2-sqrt(2*(1-uniRV)));
+}
+
 // Return a normal random number via Box-Muller transform
 // Transform will generate 2 normal RVs; 1 is kept to return in the following call
 double generateNormal(const double mean,

--- a/src/rand_accord.h
+++ b/src/rand_accord.h
@@ -42,6 +42,9 @@ void rngInitialize(const uint32_t SEED);
 // Return a uniform random number between 0 and 1 INCLUSIVE
 double generateUniform();
 
+// Return a triangular random number
+double generateTriangular();
+
 // Return a normal random number
 double generateNormal(const double mean,
 	const double variance);

--- a/src/region.c
+++ b/src/region.c
@@ -937,7 +937,7 @@ uint32_t findNearestSub(const short curRegion,
 	uint32_t numSub = regionArray[curRegion].numSubRegionNeigh[neighRegion];
 	
 	uint32_t curSub;
-	uint32_t minSub;
+	uint32_t minSub = UINT32_MAX;
 	double minDistSq = DBL_MAX;
 	double curDistSq;
 	for(curSub = 0; curSub < numSub; curSub++)

--- a/src/region.h
+++ b/src/region.h
@@ -204,6 +204,9 @@ struct region { // Region boundary parameters
 	// Number of other regions that are a neighbor of this region
 	short numRegionNeigh;
 	
+	// Does a microscopic region have at least 1 mesoscopic neighbor?
+	bool bHasMesoNeigh;
+	
 	// IDs of regions that are neighbors. Length is value of numRegionNeigh
 	// TODO: Might not need
 	short * regionNeighID;
@@ -274,6 +277,11 @@ struct region { // Region boundary parameters
 	// is microscopic.
 	// Size is NUM_REGIONS x numSubRegionNeigh x boundSubNumFace x 3
 	double (*** boundVirtualNeighCoor)[3];
+	
+	// 3D array of directions of virtual subvolumes that neighbor each
+	// subvolume in current region
+	// Size is NUM_REGIONS x numSubRegionNeigh x boundSubNumFace
+	unsigned short *** boundVirtualNeighDir;
 	
 	// 2D array of booleans to indicate whether a boundary subvolume needs its
 	// propensities updated due to molecules entering from the microscopic regime.

--- a/src/region.h
+++ b/src/region.h
@@ -10,9 +10,17 @@
  * region.h - 	operations for (microscopic or mesoscopic) regions in
  * 				simulation environment
  *
- * Last revised for AcCoRD v0.5.1 (2016-05-06)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added members to track the direction of microscopic subvolumes from mesoscopic
+ * subvolumes. Replaced array for storing coordinates of virtual microscopic
+ * subvolume with array of boundary coordinates of boundary mesoscopic subvolumes. These
+ * changes needed to accommodate improved hybrid transition algorithms
+ * - changed findNearestSub function to return index of subvolume in region's neighID array
+ * instead of the global subvolume list. This makes function suitable for more calls.
  *
  * Revision v0.5.1 (2016-05-06)
  * - updated function bPointInRegionNotChild to take an extra input to indicate
@@ -269,14 +277,12 @@ struct region { // Region boundary parameters
 	// 2D array of subvolume coordinates for subvolumes in current region that
 	// border each neighbour. Only needed if region is mesoscopic and neighbor
 	// is microscopic. Size is NUM_REGIONS x numSubRegionNeigh x 3
-	double (** boundSubCoor)[3];
+	double (** boundSubCenterCoor)[3];
 	
-	// 3D array of virtual subvolume anchor coordinates associated with each
-	// subvolume in current region that borders each neighbor.	
-	// Only needed if region is mesoscopic and neighbor
-	// is microscopic.
-	// Size is NUM_REGIONS x numSubRegionNeigh x boundSubNumFace x 3
-	double (*** boundVirtualNeighCoor)[3];
+	// 2D array of subvolume boundary coordinates for subvolumes in current region that
+	// border each neighbour. Only needed if region is mesoscopic and neighbor
+	// is microscopic. Size is NUM_REGIONS x numSubRegionNeigh x 6
+	double (** boundSubCoor)[6];
 	
 	// 3D array of directions of virtual subvolumes that neighbor each
 	// subvolume in current region

--- a/src/subvolume.c
+++ b/src/subvolume.c
@@ -10,9 +10,13 @@
  * subvolume.c - 	structure for storing subvolume properties. Simulation
  *					environment is partitioned into subvolumes
  *
- * Last revised for AcCoRD v0.5 (2016-04-15)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - improved propensity calculation for molecules to leave mesoscopic subvolume and enter
+ * virtual microscopic neighbor
  *
  * Revision v0.5 (2016-04-15)
  * - corrected memory allocation for subvolume helper arrays
@@ -934,6 +938,13 @@ void buildSubvolArray(const uint32_t numSub,
 						if(fabs(boundOverlap[4] - boundOverlap[5]) > boundAdjError)
 							subvolArray[curID].diffRateNeigh[curMolType][curNeighID] *=
 								(boundOverlap[5] - boundOverlap[4])/h_i;
+						
+						if(regionArray[neighRegion].spec.bMicro)
+						{ // Include multiplier on propensity
+							subvolArray[curID].diffRateNeigh[curMolType][curNeighID]
+								*= 2*h_i/sqrt(DIFF_COEF[curRegion][curMolType]
+								*PI*regionArray[neighRegion].spec.dt);
+						}
 					}
 				}
 			}

--- a/src/subvolume.h
+++ b/src/subvolume.h
@@ -10,9 +10,13 @@
  * subvolume.h - 	structure for storing subvolume properties. Simulation
  *					environment is partitioned into subvolumes
  *
- * Last revised for AcCoRD v0.5 (2016-04-15)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - improved propensity calculation for molecules to leave mesoscopic subvolume and enter
+ * virtual microscopic neighbor
  *
  * Revision v0.5 (2016-04-15)
  * - corrected memory allocation for subvolume helper arrays


### PR DESCRIPTION
Improved the transition rules used to move molecules between the microscopic and mesoscopic regimes. Rules are based on Flegg 2014 "Analysis of the two-regime method on square methods", and user can select between the small subvolume / large time step or large subvolume / small time step assumptions. New configuration added to demonstrate accuracy.
