### PR TITLE
Added active point actors

### DIFF
--- a/config/accord_config_sample_communication.txt
+++ b/config/accord_config_sample_communication.txt
@@ -44,8 +44,8 @@
 				interval is actually smaller than the microscopic time step, but that is fine because
 				the simulator accommodates smaller times when new molecules are created.",
 				"Is Location Defined by Regions?": false,
-				"Shape": "Rectangular Box",
-				"Outer Boundary": [-1e-12, 1e-12, -1e-12, 1e-12, -1e-12, 1e-12],
+				"Shape": "Point",
+				"Outer Boundary": [0, 0, 0],
 				"Is Actor Active?": true,
 				"Start Time": 0,
 				"Is There Max Number of Actions?": false,

--- a/config/accord_config_sample_communication_chemical.txt
+++ b/config/accord_config_sample_communication_chemical.txt
@@ -92,8 +92,8 @@
 				"Notes": "Point Transmitter at origin with 10ms symbol length. Molecules are
 					generated at random times at an expected rate that depends on the current symbol.",
 				"Is Location Defined by Regions?": false,
-				"Shape": "Rectangular Box",
-				"Outer Boundary": [-1e-12, 1e-12, -1e-12, 1e-12, -1e-12, 1e-12],
+				"Shape": "Point",
+				"Outer Boundary": [0, 0, 0],
 				"Is Actor Active?": true,
 				"Start Time": 0,
 				"Is There Max Number of Actions?": false,
@@ -130,8 +130,7 @@
 				"Is Molecule Position Observed?": [false, false]
 		},
 		{
-				"Notes": "Spherical observer. Its location must match that of the receiver region
-					in order for the reversible receiver reaction to occur",
+				"Notes": "Spherical observer at receiver",
 				"Is Location Defined by Regions?": true,
 				"List of Regions Defining Location": ["Receiver"],
 				"Is Actor Active?": false,

--- a/config/accord_config_sample_hybrid.txt
+++ b/config/accord_config_sample_hybrid.txt
@@ -98,7 +98,7 @@
 				"Is Molecule Position Observed?": [false, false]
 		},
 		{
-				"Notes": "Transmitter 1. Releases 1 molecule per 10 cubic microns",
+				"Notes": "Transmitter 1. 1000 molecules",
 				"Is Location Defined by Regions?": true,
 				"List of Regions Defining Location": ["Right", "Left"],
 				"Is Actor Active?": true,

--- a/config/accord_config_sample_point_diffusion.txt
+++ b/config/accord_config_sample_point_diffusion.txt
@@ -6,8 +6,8 @@
 		a very large radius, i.e., 1e9999 here. There are four passive actors placed to watch
 		the diffusion wave: a sphere centered at the source, two actors (one sphere and one
 		rectangle) placed some distance away, and one infinitely large actor to show that all of
-		the molecules remain in the system. The point source is not a true point but is defined
-		as a very small box. Note that the global subvolume base size is set to a correspondingly
+		the molecules remain in the system. The point source is defined as a point actor.
+		Note that the global subvolume base size is set to a correspondingly
 		low value so that the placement of the source is detected. This simulation with 10 repeats
 		should take less than 10 seconds to execute on a personal computer.",
 	"Output Filename": "accord_sample_point_diffusion",
@@ -44,8 +44,8 @@
 		{
 				"Notes": "Point Transmitter at origin",
 				"Is Location Defined by Regions?": false,
-				"Shape": "Rectangular Box",
-				"Outer Boundary": [-1e-12, 1e-12, -1e-12, 1e-12, -1e-12, 1e-12],
+				"Shape": "Point",
+				"Outer Boundary": [0, 0, 0],
 				"Is Actor Active?": true,
 				"Start Time": 0,
 				"Is There Max Number of Actions?": false,

--- a/config/accord_config_sample_reactor_microscopic.txt
+++ b/config/accord_config_sample_reactor_microscopic.txt
@@ -52,7 +52,7 @@
 		"Subvolume Base Size": 1e-6,
 		"Region Specification": [
 			{
-				"Notes": "Single mesoscopic region with 1 subvolume.",
+				"Notes": "Single microscopic region.",
 				"Label": "A",
 				"Parent Label": "",
 				"Shape": "Rectangular Box",

--- a/src/actor.h
+++ b/src/actor.h
@@ -15,6 +15,8 @@
  *
  * Revision LATEST_VERSION
  * - modified random number generation. Now use PCG via a separate interface file.
+ * - added active point sources. Can be placed in microscopic or mesoscopic regions.
+ * Cannot be on boundary of 2 or more regions or mesoscopic subvolumes
  * - made output of active actor data sequence a user option
  * - added bBits array for user to define a constant active actor bit sequence
  *

--- a/src/base.h
+++ b/src/base.h
@@ -16,6 +16,8 @@
  *
  * Revision LATEST_VERSION
  * - modified random number generation. Now use PCG via a separate interface file.
+ * - added implementation of point shapes. Implementation is not comprehensive, but enough
+ * to account for active point actors.
  *
  * Revision v0.5.1 (2016-05-06)
  * - added 2D rectangle case to point reflection. Actually only works for surface cases,

--- a/src/file_io.h
+++ b/src/file_io.h
@@ -22,6 +22,9 @@
  * this distance)
  * - made output of active actor data sequence a user option
  * - added option for user to define a constant active actor bit sequence
+ * - added point active actors defined by their 3D coordinate.
+ * - added check for positive (and not just non-negative) radii for spherical regions and
+ * actors (i.e., 0 is not a valid radius)
  * - added warnings for unnecessary active actor parameters depending on values
  * of other active actor parameters
  *

--- a/src/global_param.h
+++ b/src/global_param.h
@@ -10,9 +10,12 @@
  * global_param.h - global parameters that are independent of a specific
  * 					simulation
  *
- * Last revised for AcCoRD v0.5.1 (2016-05-06)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added POINT as a shape
  *
  * Revision v0.5.1 (2016-05-06)
  * - added types of chemical reaction probability calculations
@@ -47,7 +50,8 @@
 #define RECTANGULAR_BOX 2
 #define SPHERE 3
 #define LINE 4
-#define UNDEFINED_SHAPE 5
+#define POINT 5
+#define UNDEFINED_SHAPE 6
 
 // Types of regions
 // NOTE: Changes to list of names must be reflected in file_io.c

--- a/src/region.c
+++ b/src/region.c
@@ -21,6 +21,7 @@
  * changes needed to accommodate improved hybrid transition algorithms
  * - changed findNearestSub function to return index of subvolume in region's neighID array
  * instead of the global subvolume list. This makes function suitable for more calls.
+ * - added case for point boundary when determining intersection with a region
  *
  * Revision v0.5.1 (2016-05-06)
  * - updated function bPointInRegionNotChild to take an extra input to indicate
@@ -1008,6 +1009,15 @@ double intersectRegionVolume(const short curRegion,
 		boundary2Type, boundary2, 0.))
 	{ // Boundary is fully inside region such that there is no intersection with region boundary
 		return 0.;		
+	}
+	
+	if(boundary2Type == POINT)
+	{
+		if(bPointInRegionNotChild(curRegion, regionArray,
+			boundary2, false))
+			return INFINITY;
+		else
+			return 0.;
 	}
 	
 	// Calculate overall intersection area (including space occupied by children)

--- a/src/region.h
+++ b/src/region.h
@@ -21,6 +21,7 @@
  * changes needed to accommodate improved hybrid transition algorithms
  * - changed findNearestSub function to return index of subvolume in region's neighID array
  * instead of the global subvolume list. This makes function suitable for more calls.
+ * - added case for point boundary when determining intersection with a region
  *
  * Revision v0.5.1 (2016-05-06)
  * - updated function bPointInRegionNotChild to take an extra input to indicate


### PR DESCRIPTION
- added point as a boundary shape. Can be applied to active actors only
- active point actors can be in microscopic or mesoscopic regions, but
  cannot lie directly on boundary of multiple regions or multiple
  mesoscopic subvolumes
- updated sample config files to use point sources where appropriate
- minor corrections to comments in sample config files
