### PR TITLE
Bimolecular reactions with binding and unbinding radii

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/run_accord_rc.sh
 bin/accord_torque_ppp.sh
 bin/accord_ppp.pbs
 *.asv
+*.mp4

--- a/bin/run_accord_dub_debug_samples.sh
+++ b/bin/run_accord_dub_debug_samples.sh
@@ -11,3 +11,4 @@
 ./accord_dub_debug.out accord_config_sample_reactor_2nd_order.txt;
 ./accord_dub_debug.out accord_config_sample_reactor_microscopic.txt;
 ./accord_dub_debug.out accord_config_sample_surface.txt;
+./accord_dub_debug.out accord_config_sample_crowding.txt;

--- a/bin/run_accord_dub_samples.sh
+++ b/bin/run_accord_dub_samples.sh
@@ -11,3 +11,4 @@
 ./accord_dub.out accord_config_sample_reactor_2nd_order.txt;
 ./accord_dub.out accord_config_sample_reactor_microscopic.txt;
 ./accord_dub.out accord_config_sample_surface.txt;
+./accord_dub.out accord_config_sample_crowding.txt;

--- a/config/accord_config_sample_crowding.txt
+++ b/config/accord_config_sample_crowding.txt
@@ -1,0 +1,105 @@
+{
+	"Notes": "Notes fields replace commenting, which is not standard in JSON.",
+	"Description": "This configuration places 10 molecules in a box with a reflecting center. A bimolecular reaction is defined with a binding and unbinding radius so that a minimum distance between individual molecules is maintained. Molecule locations are recorded. This simulation should take less than 1 second to run on a personal computer.",
+	"Output Filename": "accord_sample_crowding",
+	"Warning Override": false,
+	"Simulation Control": {
+		"Number of Repeats": 1,
+		"Final Simulation Time": 0.05,
+		"Global Microscopic Time Step": 1e-4,
+		"Random Number Seed": 1,
+		"Max Number of Progress Updates": 100
+	},
+	"Chemical Properties": {
+		"Number of Molecule Types": 1,
+		"Diffusion Coefficients": [1e-9],
+		"Chemical Reaction Specification": [
+			{							
+				"Notes": "Binding reaction.",
+				"Label": "Binding",
+				"Is Reaction Reversible?": false,
+				"Surface Reaction?": false,
+				"Default Everywhere?": true,
+				"Exception Regions": [],
+				"Reactants": [2],
+				"Products": [2],
+				"Reaction Rate": 1e-14,
+				"Binding Radius": 2e-6,
+				"Unbinding Radius": 2e-6
+			}
+		]
+	},
+	"Environment":	{
+		"Subvolume Base Size": 1e-6,
+		"Region Specification": [
+			{
+				"Notes": "Microscopic box.",
+				"Label": "A",
+				"Parent Label": "",
+				"Shape": "Rectangular Box",
+				"Type": "Normal",
+				"Anchor X Coordinate": 0,
+				"Anchor Y Coordinate": 0,
+				"Anchor Z Coordinate": 0,
+				"Integer Subvolume Size": 1,
+				"Is Region Microscopic?": true,
+				"Number of Subvolumes Along X": 10,
+				"Number of Subvolumes Along Y": 10,
+				"Number of Subvolumes Along Z": 1
+			},
+			{
+				"Notes": "Microscopic box.",
+				"Label": "B",
+				"Parent Label": "A",
+				"Shape": "Rectangular Box",
+				"Type": "3D Surface",
+				"Surface Type": "Outer",
+				"Anchor X Coordinate": 2e-6,
+				"Anchor Y Coordinate": 2e-6,
+				"Anchor Z Coordinate": 0,
+				"Integer Subvolume Size": 1,
+				"Is Region Microscopic?": true,
+				"Number of Subvolumes Along X": 6,
+				"Number of Subvolumes Along Y": 6,
+				"Number of Subvolumes Along Z": 1
+			}
+		],
+		"Actor Specification": [
+		{
+				"Notes": "Molecule initialization",
+				"Is Location Defined by Regions?": true,
+				"List of Regions Defining Location": ["A"],
+				"Is Actor Active?": true,
+				"Start Time": 0,
+				"Is There Max Number of Actions?": false,
+				"Is Actor Independent?": true,
+				"Action Interval": 1e9999,
+				"Is Actor Activity Recorded?": true,
+				"Random Number of Molecules?": false,
+				"Random Molecule Release Times?": false,
+				"Release Interval": 0,
+				"Slot Interval": 0,
+				"Bits Random?": true,
+				"Probability of Bit 1": 1,
+				"Modulation Scheme": "CSK",
+				"Modulation Bits": 1,
+				"Modulation Strength": 10,
+				"Is Molecule Type Released?": [true]
+		},
+		{
+				"Notes": "Box observer that logs molecule positions",
+				"Is Location Defined by Regions?": true,
+				"List of Regions Defining Location": ["A"],
+				"Is Actor Active?": false,
+				"Start Time": 1e-10,
+				"Is There Max Number of Actions?": false,
+				"Is Actor Independent?": true,
+				"Action Interval": 1e-4,
+				"Is Actor Activity Recorded?": true,
+				"Is Time Recorded with Activity?": false,
+				"Is Molecule Type Observed?": [true],
+				"Is Molecule Position Observed?": [true]
+		}
+		]		
+	}
+}

--- a/matlab/accordConfigImport.m
+++ b/matlab/accordConfigImport.m
@@ -62,12 +62,12 @@ chemStruct = struct('label', '', 'bReversible', 0, 'revLabel', '', ...
 config.chemRxn = cell(1, config.numChemRxn);
 for i = 1:config.numChemRxn
     config.chemRxn{i} = chemStruct;
-    if config.numChemRxn == 1
-        curRxn = ...
-            configJSON.Chemical_0x20_Properties.Chemical_0x20_Reaction_0x20_Specification;
-    else
+    if iscell(configJSON.Chemical_0x20_Properties.Chemical_0x20_Reaction_0x20_Specification)
         curRxn = ...
             configJSON.Chemical_0x20_Properties.Chemical_0x20_Reaction_0x20_Specification{i};
+    else
+        curRxn = ...
+            configJSON.Chemical_0x20_Properties.Chemical_0x20_Reaction_0x20_Specification(i);
     end
     
     config.chemRxn{i}.rate = curRxn.Reaction_0x20_Rate;
@@ -133,10 +133,10 @@ regionStruct = struct('label', '', 'parent', '', 'shape', '', ...
 config.region = cell(1, config.numRegion);
 for i = 1:config.numRegion
     config.region{i} = regionStruct;
-    if config.numRegion == 1
-        curRegion = configJSON.Environment.Region_0x20_Specification;
-    else
+    if iscell(configJSON.Environment.Region_0x20_Specification)
         curRegion = configJSON.Environment.Region_0x20_Specification{i};
+    else
+        curRegion = configJSON.Environment.Region_0x20_Specification(i);
     end
     
     config.region{i}.label = curRegion.Label;
@@ -181,10 +181,10 @@ config.numActive = 0;
 config.numPassive = 0;
 for i = 1:config.numActor
     config.actor{i} = actorStruct;
-    if config.numActor == 1
-        curActor = configJSON.Environment.Actor_0x20_Specification;
-    else
+    if iscell(configJSON.Environment.Actor_0x20_Specification)
         curActor = configJSON.Environment.Actor_0x20_Specification{i};
+    else
+        curActor = configJSON.Environment.Actor_0x20_Specification(i);
     end
     
     % How is actor space defined
@@ -258,10 +258,10 @@ passiveStruct = struct('bRecordTime', 0, 'bRecordMolCount', zeros(1,config.numMo
 curActive = 1;
 curPassive = 1;
 for i = 1:config.numActor
-    if config.numActor == 1
-        curActor = configJSON.Environment.Actor_0x20_Specification;
-    else
+    if iscell(configJSON.Environment.Actor_0x20_Specification)
         curActor = configJSON.Environment.Actor_0x20_Specification{i};
+    else
+        curActor = configJSON.Environment.Actor_0x20_Specification(i);
     end
     
     if config.actor{i}.bActive

--- a/matlab/accordVideoMaker.m
+++ b/matlab/accordVideoMaker.m
@@ -146,12 +146,7 @@ else
     [curFig, curAxes] = accordPlotEnvironment(config, axesProp, figureProp, ...
         regionDispStruct, actorDispStruct, scale);
     hFig(1) = curFig;
-    hAxes(1) = curAxes;
-    
-    % Check with user if number of frames is large
-    if numFrames > 10
-        warning('Configuration will create %d figures instead of a video, which is a large number of new windows', numFrames);
-    end
+    hAxes(1) = curAxes;    
 end
 
 %% Allow User To Adjust Environment View and Set Dynamic Behavior
@@ -185,7 +180,7 @@ if bDynamicCamera
         'CameraViewAngle','CameraUpVector'}, cameraAnchorArray{1});
 else
     disp('NOTE: No camera anchor points already defined by wrapper file.');
-    disp('	If accordDynamicCamera is not called, then camera settings.');
+    disp('	If accordDynamicCamera is not called, then camera settings');
     disp('	will not be changed when video generation starts.');
     frameCameraAnchor = zeros(1,numFrames);
 end
@@ -207,6 +202,10 @@ numAnnotatedFrames = 0;
 frameAnnotation = zeros(1, numFrames);
 
 disp('Type dbcont to continue or dbquit to quit');
+% Check with user if number of frames is large
+if ~bMakeVideo && numFrames > 10
+    warning('Configuration will create %d figures instead of a video, which is a large number of new figure windows', numFrames);
+end
 keyboard
 
 %% Lock in axis limits and store inital camera view

--- a/src/accord.c
+++ b/src/accord.c
@@ -17,6 +17,8 @@
  * - improved placement of molecules from mesoscopic regime into microscopic regime. User
  * can choose between small time step / large subvolume or large time step / small subvolume
  * algorithms via config. Actual placement moved to function in micro_molecule source file
+ * - added bimolecular chemical reactions in microscopic regime (via binding and unbinding
+ * radii)
  * - modified random number generation. Now use PCG via a separate interface file.
  * - made output of active actor data sequence a user option
  *
@@ -745,7 +747,7 @@ int main(int argc, char *argv[])
 					{ // For current molecule type in this region
 					
 						if(!isListMol3DEmpty(&microMolList[i][j])
-							&& regionArray[i].numFirstCurReactant[j] > 0)
+							&& regionArray[i].numFirstRxnWithReactant[j] > 0)
 						{ // Check 1st order reactions of "old" molecules
 							rxnFirstOrder(spec.NUM_REGIONS, spec.NUM_MOL_TYPES, i,
 								microMolList, regionArray, j,
@@ -768,7 +770,7 @@ int main(int argc, char *argv[])
 						{ // For current molecule type in this region
 						
 							if(!isListMol3DRecentEmpty(&microMolListRecent[i][j])
-								&& regionArray[i].numFirstCurReactant[j] > 0)
+								&& regionArray[i].numFirstRxnWithReactant[j] > 0)
 							{ // Check 1st order reactions of "old" molecules
 								rxnFirstOrderRecent(spec.NUM_REGIONS,
 									spec.NUM_MOL_TYPES, i, microMolListRecent,
@@ -780,7 +782,7 @@ int main(int argc, char *argv[])
 						for(j = 0; j < spec.NUM_MOL_TYPES; j++)
 						{ // For current molecule type in this region
 						
-							if(regionArray[i].numFirstCurReactant[j] < 1)
+							if(regionArray[i].numFirstRxnWithReactant[j] < 1)
 							{ 
 								numMicroMolCheck[i][j] = 0;
 							}
@@ -806,9 +808,12 @@ int main(int argc, char *argv[])
 				// Diffuse all microscopic molecules to valid locations and merge
 				// 2 sets of molecule lists into 1
 				diffuseMolecules(spec.NUM_REGIONS, spec.NUM_MOL_TYPES, microMolList,
-					microMolListRecent, regionArray, mesoSubArray, subvolArray,
+					microMolListRecent, regionArray, subvolArray,
 					micro_sigma, spec.chem_rxn, spec.MAX_HYBRID_DIST, DIFF_COEF);
 				
+				// Execute 2nd Order Reactions
+				rxnSecondOrder(spec.NUM_REGIONS, spec.NUM_MOL_TYPES, microMolList,
+					regionArray, subvolArray, spec.chem_rxn, DIFF_COEF);
 				
 				if(numMesoSub > 0)
 				{

--- a/src/actor.c
+++ b/src/actor.c
@@ -17,6 +17,8 @@
  * - modified random number generation. Now use PCG via a separate interface file.
  * - added active point sources. Can be placed in microscopic or mesoscopic regions.
  * Cannot be on boundary of 2 or more regions or mesoscopic subvolumes
+ * - added second order chemical reactions in the microscopic regime via a binding radius
+ * and unbinding radius (can also model molecular crowding)
  * - made output of active actor data sequence a user option
  * - added bBits array for user to define a constant active actor bit sequence
  *

--- a/src/base.c
+++ b/src/base.c
@@ -18,6 +18,9 @@
  * - modified random number generation. Now use PCG via a separate interface file.
  * - added implementation of point shapes. Implementation is not comprehensive, but enough
  * to account for active point actors.
+ * - added new version of function for the distance between 2 points where the coordinates
+ * of one point are defined as separate variables
+ * - added sphere as trivial case in function for finding a shape's closest face
  *
  * Revision v0.5.1 (2016-05-06)
  * - added 2D rectangle case to point reflection. Actually only works for surface cases,
@@ -1150,6 +1153,9 @@ int closestFace(const double point[3],
 				}
 			}
 			return minFace;
+		case SPHERE:
+			// Sphere has only 1 face so it must be the closest
+			return 0;
 		default:
 			fprintf(stderr,"ERROR: Cannot determine the distance from a %s.\n",
 				boundaryString(boundary1Type));
@@ -1291,6 +1297,30 @@ void defineLine(const double p1[3],
 		L[1] = 0.;
 		L[2] = 0.;
 		*length = 0.;
+	}
+}
+
+// Define unit vector pointing from one point to another
+// This version defines 2nd point as individual arguments
+// and does not return the length of the line
+void defineLine2(const double p1[3],
+	const double p2x,
+	const double p2y,
+	const double p2z,
+	double L[3])
+{
+	double length = sqrt(squareDBL(p2x-p1[0]) + squareDBL(p2y-p1[1]) + squareDBL(p2z-p1[2]));
+	
+	if (length > 0.)
+	{
+		L[0] = (p2x-p1[0])/length;
+		L[1] = (p2y-p1[1])/length;
+		L[2] = (p2z-p1[2])/length;
+	} else
+	{
+		L[0] = 0.;
+		L[1] = 0.;
+		L[2] = 0.;
 	}
 }
 

--- a/src/base.h
+++ b/src/base.h
@@ -18,6 +18,9 @@
  * - modified random number generation. Now use PCG via a separate interface file.
  * - added implementation of point shapes. Implementation is not comprehensive, but enough
  * to account for active point actors.
+ * - added new version of function for the distance between 2 points where the coordinates
+ * of one point are defined as separate variables
+ * - added sphere as trivial case in function for finding a shape's closest face
  *
  * Revision v0.5.1 (2016-05-06)
  * - added 2D rectangle case to point reflection. Actually only works for surface cases,
@@ -215,6 +218,15 @@ void defineLine(const double p1[3],
 	const double p2[3],
 	double L[3],
 	double * length);
+
+// Define unit vector pointing from one point to another
+// This version defines 2nd point as individual arguments
+// and does not return the length of the line
+void defineLine2(const double p1[3],
+	const double p2x,
+	const double p2y,
+	const double p2z,
+	double L[3]);
 
 // Determine volume of boundary
 //

--- a/src/chem_rxn.h
+++ b/src/chem_rxn.h
@@ -9,9 +9,18 @@
  *
  * chem_rxn.h - structure for storing chemical reaction properties
  *
- * Last revised for AcCoRD v0.5.1 (2016-05-06)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - preliminary implementation of bimolecular reactions in microscopic regime
+ * (based on binding and unbinding radii). Can also model molecular crowding
+ * - added new members to region array structure to facilitate microscopic
+ * bimolecular reactions
+ * - added indicator for whether reactions in the global reaction lists can occur
+ * in given region, which is needed to asses bimolecular reactions where the
+ * reactants are in different regions
  *
  * Revision v0.5.1 (2016-05-06)
  * - added label, bReversible, and labelCoupled so that reactions can be named
@@ -94,6 +103,14 @@ struct chem_rxn_struct { // Used to define a single chemical reaction
 	
 	// Base reaction rate k (units depends on order of reaction)
 	double k;
+	
+	// Binding radius (defined for mircoscopic bimolecular reactions)
+	// Default is 0 (molecules effectively do not react)
+	double rBind;
+	
+	// Unbinding radius (defined for microscopic reactions with multiple products)
+	// Default is 0 (products are left at same location as reactant)
+	double rUnbind;
 	
 	// Is the reaction a surface reaction?
 	// This will affect where a reaction will take place by default,

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -20,6 +20,8 @@
  * - added option for user to choose maximum distance beyond which a micro to mesoscopic
  * substep transition will not be considered (either initial or final point should be beyond
  * this distance)
+ * - added binding and unbinding radii as bimolecular reaction parameters (needed in
+ * microscopic regime)
  * - made output of active actor data sequence a user option
  * - added option for user to define a constant active actor bit sequence
  * - added point active actors defined by their 3D coordinate.
@@ -698,6 +700,39 @@ void loadConfig(const char * CONFIG_NAME,
 					
 					curSpec->chem_rxn[curArrayItem].k = 
 						cJSON_GetObjectItem(curObj, "Reaction Rate")->valuedouble;
+					
+					// Check for binding and unbinding radii
+					if(cJSON_bItemValid(curObj,"Binding Radius", cJSON_Number))
+					{
+						if(cJSON_GetObjectItem(curObj, "Binding Radius")->valuedouble >= 0.)
+						{
+							curSpec->chem_rxn[curArrayItem].rBind = 
+								cJSON_GetObjectItem(curObj, "Binding Radius")->valuedouble;
+						} else
+						{
+							bWarn = true;
+							printf("WARNING %d: Reaction %d has an invalid binding radius. Setting to default value of \"0\".\n", numWarn++, curArrayItem);
+							curSpec->chem_rxn[curArrayItem].rBind = 0.;
+						}
+					} else
+						curSpec->chem_rxn[curArrayItem].rBind = 0.;
+					
+					if(cJSON_bItemValid(curObj,"Unbinding Radius", cJSON_Number))
+					{						
+						if(cJSON_GetObjectItem(curObj, "Unbinding Radius")->valuedouble >= 0.)
+						{
+							curSpec->chem_rxn[curArrayItem].rUnbind = 
+								cJSON_GetObjectItem(curObj, "Unbinding Radius")->valuedouble;
+						} else
+						{
+							bWarn = true;
+							printf("WARNING %d: Reaction %d has an invalid unbinding radius. Setting to default value of \"0\".\n", numWarn++, curArrayItem);
+							curSpec->chem_rxn[curArrayItem].rUnbind = 0.;
+						}
+					} else
+						curSpec->chem_rxn[curArrayItem].rUnbind = 0.;
+					
+					// Read array of reactant stoichiometry
 					curObjInner = cJSON_GetObjectItem(curObj,"Reactants");
 					for(curMolType = 0; curMolType < curSpec->NUM_MOL_TYPES;
 					curMolType++)
@@ -715,6 +750,7 @@ void loadConfig(const char * CONFIG_NAME,
 						}
 					}
 					
+					// Read array of product stoichiometry
 					curObjInner = cJSON_GetObjectItem(curObj,"Products");
 					for(curMolType = 0; curMolType < curSpec->NUM_MOL_TYPES;
 					curMolType++)

--- a/src/file_io.h
+++ b/src/file_io.h
@@ -20,6 +20,8 @@
  * - added option for user to choose maximum distance beyond which a micro to mesoscopic
  * substep transition will not be considered (either initial or final point should be beyond
  * this distance)
+ * - added binding and unbinding radii as bimolecular reaction parameters (needed in
+ * microscopic regime)
  * - made output of active actor data sequence a user option
  * - added option for user to define a constant active actor bit sequence
  * - added point active actors defined by their 3D coordinate.

--- a/src/region.c
+++ b/src/region.c
@@ -19,6 +19,8 @@
  * subvolumes. Replaced array for storing coordinates of virtual microscopic
  * subvolume with array of boundary coordinates of boundary mesoscopic subvolumes. These
  * changes needed to accommodate improved hybrid transition algorithms
+ * - added members to implement bimolecular chemical reactions in microscopic regime.
+ * Use a preliminary algorithm where the user must supply the binding and unbinding radii
  * - changed findNearestSub function to return index of subvolume in region's neighID array
  * instead of the global subvolume list. This makes function suitable for more calls.
  * - added case for point boundary when determining intersection with a region


### PR DESCRIPTION
- added bimolecular chemical reactions to microscopic regime. User must
  provide binding radius and (if applicable) unbinding radius. Potential
  reactants are compared with other potential reactants in same region and
  neighboring regions where the reaction could also take place. A molecule
  cannot participate in more than one bimolecular reaction per time step.
  Reaction site is found based on relative diffusion of reactants and must
  be a valid straight line destination for both both reactants. If there
  is a binding radius, trajectory of product molecules is also verified.
  If 2 products, then they are placed along line between the 2 reactant
  locations. If more than 2, then each is placed in a random direction.
- added sample configuration for a "crowding" scenario
- fixed index referencing of regions, actors, and reactions when
  importing configuration files to Matlab
- Made warning more apparent when creating a large number of figures in
  Matlab
- added indicator to check whether a particular global reaction can
  occur in a given region
- added check on total number of chemical reactions in a surface region
  before checking for surface reactions when a molecule crosses it. This
  was needed because the region structure members to indicate surface
  reactions are not created if a region has no reactions at all
- corrected bug where molecule is not correctly reflected off of a child
  region surface
