### PR TITLE
Fixhybridzerodiffusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/accord_ppp.pbs
 *.asv
 *.mp4
 bsc*
+accord_config_0*

--- a/matlab/accordBuildObserverStruct.m
+++ b/matlab/accordBuildObserverStruct.m
@@ -118,7 +118,7 @@ function obsSpec = accordBuildObserverStruct(propChange)
 % probability of success is probability of given molecule being observed.
 % - set data1 as vector to list x-axis values (would be reference times in
 % corresponding simulation curve). In 2D, this can be any number of values
-% if 'trialProbability' has length less than 3 since only calculation will
+% if 'trialProbability' has length less than 3 since only 1 calculation will
 % be made and the same value will be plotted for each point.
 % - in 2D, set 'data2' to format [val1, val2], where val1 is the number of
 % random numbers to generate (i.e., observe) for each variable in the

--- a/matlab/accordEmptyEnvironment.m
+++ b/matlab/accordEmptyEnvironment.m
@@ -58,6 +58,9 @@ function [hFig, hAxes] = accordEmptyEnvironment(fileToLoad, scale, ...
 %
 % Created 2016-06-28
 
+% Add subdirectory with JSONlab files to path (needed for loadjson)
+addpath('JSONlab');
+
 %% Load Configuration File
 % Config file is in JSON format
 opt.SimplifyCell = 1;

--- a/matlab/accordPlotEnvironment.m
+++ b/matlab/accordPlotEnvironment.m
@@ -192,6 +192,9 @@ function [scaleDim, plane, anchorCoor] = accordActorPlotParam(actor)
                 plane = 3;
             end
         end
+    elseif strcmp(actor.shape, 'Point')
+        anchorCoor = [actor.boundary(1) actor.boundary(2) actor.boundary(3)];
+        scaleDim = 0;
     elseif strcmp(actor.shape, 'Sphere')
         anchorCoor = [actor.boundary(1) actor.boundary(2) actor.boundary(3)];
         scaleDim = actor.boundary(4);

--- a/matlab/accordPlotMaker.m
+++ b/matlab/accordPlotMaker.m
@@ -56,6 +56,9 @@ function [hFig, hAxes, hCurve] = accordPlotMaker(hAxes, fileToLoad,...
 % Created 2016-06-03
 
 
+% Add subdirectory with JSONlab files to path (needed for loadjson)
+addpath('JSONlab');
+
 %% Load Default Display Properties and Apply Specified Changes
 obsSpec = accordBuildObserverStruct(customObsProp);
 

--- a/matlab/accordPlotMakerWrapper.m
+++ b/matlab/accordPlotMakerWrapper.m
@@ -24,9 +24,13 @@ function [hFig, hAxes] = accordPlotMakerWrapper()
 % hFig - handle(s) to plotted figure(s). Use for making changes.
 % hAxes - handle(s) to axes in plotted figure(s). Use for making changes.
 %
-% Last revised for AcCoRD v0.7 (public beta, 2016-07-09)
+% Last revised for AcCoRD LATEST_VERSION
 %
 % Revision history:
+%
+% Revision LATEST_VERSION
+% - changed axes clipping to 'on'
+% - Minor updates to comments
 %
 % Revision v0.7 (public beta, 2016-07-09)
 % - Created file
@@ -59,12 +63,12 @@ customFigProp = [];
 %   generation and not curve plotting
 customAxesProp.Visible = 'on';
 customAxesProp.Projection = 'orthographic';
+customAxesProp.Clipping = 'on';
 
 % passiveActorToPlot - index of passive recording actors whose
-%   molecules are to be plotted. Indexing matches the list of passive
+%   signals are to be plotted. Indexing matches the list of passive
 %   actors whose observations are recorded (as stored in the data structure
-%   in fileToLoad). Actors listed here will NOT have their shapes plotted
-%   (use actorToPlot to plot specific actors).
+%   in fileToLoad).
 passiveID = 1;
 
 % molID - index of molecules to display. Indexing corresponds to the

--- a/src/accord.c
+++ b/src/accord.c
@@ -9,9 +9,13 @@
  *
  * accord.c - main file
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added measurement of simulation runtime to be written to simulation output
+ * - corrected passive actor indexing
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - improved placement of molecules from mesoscopic regime into microscopic regime. User
@@ -194,6 +198,7 @@ int main(int argc, char *argv[])
 						   // TODO: Should these IDs be from actor list or passive list?
 	
 	clock_t startTime, endTime; // Time record keeping
+	double runTime; 				// Runtime for realizations
 	
 	double DIFF_COEF [spec.NUM_REGIONS][spec.NUM_MOL_TYPES];
 	for(i = 0; i < spec.NUM_REGIONS; i++)
@@ -570,7 +575,7 @@ int main(int argc, char *argv[])
 							actorPassiveArray[curPassive].molRecordID[curMolPassive];
 						// Will molecule coordinates be recorded
 						bRecordPos =
-							actorCommonArray[heapTimer[0]].spec.bRecordPos[curMolPassive];
+							actorCommonArray[heapTimer[0]].spec.bRecordPos[curMolType];
 												
 						actorPassiveArray[curPassive].curMolObs[curMolPassive] = 0ULL;
 						// Search for molecules in each region in actor
@@ -988,7 +993,8 @@ int main(int argc, char *argv[])
 	strftime(timeBuffer, 26, "%Y-%m-%d %H:%M:%S", timeInfo);
 	printf("Ending simulation at %s.\n", timeBuffer);
 	endTime = clock();
-	printf("Simulation ran in %f seconds\n", (double) (endTime-startTime)/CLOCKS_PER_SEC);
+	runTime = (double) (endTime-startTime)/CLOCKS_PER_SEC;
+	printf("Simulation ran in %f seconds\n", runTime);
 	
 	//
 	// STEP 5: Save Output Summary
@@ -999,7 +1005,7 @@ int main(int argc, char *argv[])
 	// Print end time and info used to help Matlab importing
 	printTextEnd(outSummary, numActiveRecord, numPassiveRecord, actorCommonArray,
 		actorActiveArray, actorPassiveArray,
-		passiveRecordID, activeRecordID, maxActiveBits, maxPassiveObs);
+		passiveRecordID, activeRecordID, maxActiveBits, maxPassiveObs, runTime);
 		
 	//
 	// STEP 6: Free Memory

--- a/src/base.c
+++ b/src/base.c
@@ -10,9 +10,12 @@
  * base.c - general utility functions that can apply to different simulation data
  * 			structures
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - corrected calculation for spherical volume (was partially integer)
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - modified random number generation. Now use PCG via a separate interface file.
@@ -1354,7 +1357,7 @@ double boundaryVolume(const int boundary1Type,
 		case CIRCLE:
 			return PI*squareDBL(boundary1[3]);
 		case SPHERE:
-			return 4/3*PI*boundary1[3]*boundary1[3]*boundary1[3];
+			return 4./3.*PI*boundary1[3]*boundary1[3]*boundary1[3];
 		case LINE:
 			return sqrt(squareDBL(boundary1[1]-boundary1[0])
 				+ squareDBL(boundary1[3]-boundary1[2])

--- a/src/base.h
+++ b/src/base.h
@@ -10,9 +10,12 @@
  * base.h - general utility functions that can apply to different simulation data
  * 			structures
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - corrected calculation for spherical volume (was partially integer)
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - modified random number generation. Now use PCG via a separate interface file.

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -9,9 +9,13 @@
  *
  * file_io.c - interface with JSON configuration files
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added measurement of simulation runtime to be written to simulation output
+ * - fixed bug in writing index of active actor in simulation summary
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - added option for user to select small subvolume or big subvolume assumption
@@ -2168,7 +2172,8 @@ void printTextEnd(FILE * out,
 	short * passiveRecordID,
 	short * activeRecordID,
 	uint32_t maxActiveBits[],
-	uint32_t maxPassiveObs[])
+	uint32_t maxPassiveObs[],
+	double runTime)
 {
 	time_t timer;
 	char timeBuffer[26];
@@ -2193,8 +2198,7 @@ void printTextEnd(FILE * out,
 	{
 		curActor = activeRecordID[curActorRecord];
 		newActor = cJSON_CreateObject();
-		cJSON_AddNumberToObject(newActor, "ID",
-			actorActiveArray[curActor].actorID);
+		cJSON_AddNumberToObject(newActor, "ID", curActor);
 		cJSON_AddNumberToObject(newActor, "MaxBitLength",
 			maxActiveBits[curActorRecord]);
 		cJSON_AddItemToArray(curArray, newActor);
@@ -2209,8 +2213,7 @@ void printTextEnd(FILE * out,
 		curPassive = actorCommonArray[curActor].passiveID;
 		newActor = cJSON_CreateObject();
 		// Record Passive Actor IDs that are being recorded
-		cJSON_AddNumberToObject(newActor, "ID",
-			curActor);
+		cJSON_AddNumberToObject(newActor, "ID", curActor);
 		cJSON_AddNumberToObject(newActor, "bRecordTime",
 			actorCommonArray[curActor].spec.bRecordTime);
 		// Record maximum number of observations made by each recorded actor
@@ -2238,6 +2241,8 @@ void printTextEnd(FILE * out,
 	}
 	
 	cJSON_AddStringToObject(root, "EndTime", timeBuffer);
+	
+	cJSON_AddNumberToObject(root, "RunTime", runTime);
 	
 	outText = cJSON_Print(root);
 	fprintf(out, "%s", outText);

--- a/src/file_io.h
+++ b/src/file_io.h
@@ -9,9 +9,13 @@
  *
  * file_io.h - interface with JSON configuration files
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added measurement of simulation runtime to be written to simulation output
+ * - fixed bug in writing index of active actor in simulation summary
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - added option for user to select small subvolume or big subvolume assumption
@@ -171,6 +175,7 @@ void printTextEnd(FILE * out,
 	short * passiveRecordID,
 	short * activeRecordID,
 	uint32_t maxActiveBits[],
-	uint32_t maxPassiveObs[]);
+	uint32_t maxPassiveObs[],
+	double runTime);
 
 #endif // FILE_IO_H

--- a/src/rand_accord.c
+++ b/src/rand_accord.c
@@ -9,9 +9,13 @@
  *
  * rand_accord.c - interface to random number generation functions
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - modified range of uniform RV generation to be [0, 1) instead of [0,1].
+ * 	Allowing 1 was causing problems when RV was being used for indexing
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - file created to centralize calls to random number generators
@@ -32,8 +36,8 @@ void rngInitialize(const uint32_t SEED)
 // Return a uniform random number between 0 and 1 INCLUSIVE
 double generateUniform()
 {	
-	// Using a "dumb" conversion, which gives us range of [0, 1]
-	return (double) pcg32_random()/UINT32_MAX;
+	// Using conversion which gives us range of [0, 1)
+	return (double) pcg32_random()/(UINT32_MAX + 1.);
 }
 
 // Return a triangular random number

--- a/src/region.c
+++ b/src/region.c
@@ -10,9 +10,13 @@
  * region.c - 	operations for (microscopic or mesoscopic) regions in
  * 				simulation environment
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - corrected calculating region volume when a normal region has a surface child
+ * inside
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - added members to track the direction of microscopic subvolumes from mesoscopic
@@ -587,9 +591,8 @@ double findRegionVolume(const struct region regionArray[],
 			switch(regionArray[curRegion].spec.type)
 			{
 				case REGION_NORMAL:
-					// Only find volume if child is of same type and dimension
-					if(regionArray[childID].spec.type == REGION_NORMAL
-						&& regionArray[curRegion].plane == regionArray[childID].plane)
+					// Only find volume if child is of same dimension
+					if(regionArray[curRegion].plane == regionArray[childID].plane)
 					{
 						volume -= boundaryVolume(regionArray[childID].spec.shape,
 							regionArray[childID].boundary);

--- a/src/region.h
+++ b/src/region.h
@@ -10,9 +10,13 @@
  * region.h - 	operations for (microscopic or mesoscopic) regions in
  * 				simulation environment
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - corrected calculating region volume when a normal region has a surface child
+ * inside
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - added members to track the direction of microscopic subvolumes from mesoscopic

--- a/src/subvolume.c
+++ b/src/subvolume.c
@@ -10,9 +10,13 @@
  * subvolume.c - 	structure for storing subvolume properties. Simulation
  *					environment is partitioned into subvolumes
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - fixed bug where a molecule with diffusion rate 0 would have an invalid reaction
+ * propensity at hybrid interface
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - improved propensity calculation for molecules to leave mesoscopic subvolume and enter
@@ -940,7 +944,8 @@ void buildSubvolArray(const uint32_t numSub,
 							subvolArray[curID].diffRateNeigh[curMolType][curNeighID] *=
 								(boundOverlap[5] - boundOverlap[4])/h_i;
 						
-						if(regionArray[neighRegion].spec.bMicro)
+						if(regionArray[neighRegion].spec.bMicro &&
+							DIFF_COEF[curRegion][curMolType] > 0.)
 						{ // Include multiplier on propensity
 							subvolArray[curID].diffRateNeigh[curMolType][curNeighID]
 								*= 2*h_i/sqrt(DIFF_COEF[curRegion][curMolType]


### PR DESCRIPTION
Fixed some minor bugs
- allow diffusion coefficient 0 for molecules in hybrid environments
- changed range of uniform RV generation to avoid getting "1", which was causing problems when using RV for random array indexing
- added simulation runtime to output summary
- removed error case when trying to plot a point from a configuration. Won't actually plot anything but now won't cause error
- fixed some actor indexing bugs
- fixed some volume calculations
