### PR TITLE
Local diffusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bin/accord_torque_ppp.sh
 bin/accord_ppp.pbs
 *.asv
 *.mp4
+*.avi
 bsc*
 accord_config_0*
 accord_plot_*

--- a/matlab/accordConfigImport.m
+++ b/matlab/accordConfigImport.m
@@ -36,6 +36,8 @@ function config =  accordConfigImport(configJSON)
 % "burst" modulation, which does not modulate data
 % - enable import of multiple diffusion coefficients for each molecule type
 % (one per region)
+% - added import of surface reaction diffusion coefficient when it has been
+% specified
 %
 % Revision v0.7.0.1 (public beta, 2016-08-30)
 % - corrected import of surface reaction probability type when the surface
@@ -99,6 +101,10 @@ for i = 1:config.numChemRxn
         if ~strcmp(config.chemRxn{i}.surfRxnType, 'Normal')
             config.chemRxn{i}.surfTransProb = ...
                 curRxn.Surface_0x20_Transition_0x20_Probability;
+        end
+        if isfield(curRxn, 'Surface_0x20_Reaction_0x20_Diffusion_0x20_Coefficient')
+            config.chemRxn{i}.diffusion = ...
+                curRxn.Surface_0x20_Reaction_0x20_Diffusion_0x20_Coefficient;
         end
     end
     

--- a/src/accord.c
+++ b/src/accord.c
@@ -9,9 +9,12 @@
  *
  * accord.c - main file
  *
- * Last revised for AcCoRD v0.7.0.1 (public beta, 2016-08-30)
+ * Last revised for LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - enabled local diffusion coefficients
  *
  * Revision v0.7.0.1 (public beta, 2016-08-30)
  * - added measurement of simulation runtime to be written to simulation output
@@ -203,9 +206,18 @@ int main(int argc, char *argv[])
 	double DIFF_COEF [spec.NUM_REGIONS][spec.NUM_MOL_TYPES];
 	for(i = 0; i < spec.NUM_REGIONS; i++)
 	{
-		for(j = 0; j < spec.NUM_MOL_TYPES; j++)
+		if(spec.subvol_spec[i].bLocalDiffusion)
 		{
-			DIFF_COEF[i][j] = spec.DIFF_COEF[j];
+			for(j = 0; j < spec.NUM_MOL_TYPES; j++)
+			{
+				DIFF_COEF[i][j] = spec.subvol_spec[i].diffusion[j];
+			}
+		} else
+		{
+			for(j = 0; j < spec.NUM_MOL_TYPES; j++)
+			{
+				DIFF_COEF[i][j] = spec.DIFF_COEF[j];
+			}
 		}
 	}
 		
@@ -371,7 +383,6 @@ int main(int argc, char *argv[])
 	// Initialize random number generation
 	printf("Starting up random number generator with seed offset: %u\n", spec.SEED);
 	rngInitialize(spec.SEED);
-	//mt_seed32(spec.SEED + 5489UL); // Offset by mersenne twister default seed
 	
 	//
 	// STEP 4: Run Simulation

--- a/src/chem_rxn.h
+++ b/src/chem_rxn.h
@@ -9,9 +9,15 @@
  *
  * chem_rxn.h - structure for storing chemical reaction properties
  *
- * Last revised for AcCoRD v0.6 (public beta, 2016-05-30)
+ * Last revised for LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - enabled local diffusion coefficients. Chemical reactions involving surface
+ * interactions can specify the diffusion coefficient to use in transition
+ * probabilities as a reaction parameter (default is the molecule's default
+ * diffusion coefficient)
  *
  * Revision v0.6 (public beta, 2016-05-30)
  * - preliminary implementation of bimolecular reactions in microscopic regime
@@ -117,6 +123,11 @@ struct chem_rxn_struct { // Used to define a single chemical reaction
 	// as indicated by bEverywhere
 	bool bSurface;
 	
+	// Diffusion coefficient used for calculating surface reaction probabilities
+	// Default value is the reactant's default diffusion coefficient.
+	// Can be over-ridden by the reaction configuration
+	double diffusion;
+	
 	// Are products of a surface reaction released from surface?
 	// If true for given product, then the product molecule is placed in closest neighboring
 	// region when it is created.
@@ -180,8 +191,7 @@ bool calculateDesorptionProb(double * rxnProb,
 	const double dt,
 	const short NUM_REGIONS,
 	const struct region regionArray[],
-	const unsigned short NUM_MOL_TYPES,
-	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES]);
+	const unsigned short NUM_MOL_TYPES);
 
 // Calculate probability of absorption reaction for specified time step
 double calculateAbsorptionProb(const short curRegion,
@@ -190,8 +200,7 @@ double calculateAbsorptionProb(const short curRegion,
 	const double dt,
 	const short NUM_REGIONS,
 	const struct region regionArray[],
-	const unsigned short NUM_MOL_TYPES,
-	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES]);
+	const unsigned short NUM_MOL_TYPES);
 
 // Calculate probability of membrane transition for specified time step
 double calculateMembraneProb(const short curRegion,
@@ -200,7 +209,6 @@ double calculateMembraneProb(const short curRegion,
 	const double dt,
 	const short NUM_REGIONS,
 	const struct region regionArray[],
-	const unsigned short NUM_MOL_TYPES,
-	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES]);
+	const unsigned short NUM_MOL_TYPES);
 
 #endif // CHEM_RXN_H

--- a/src/file_io.h
+++ b/src/file_io.h
@@ -20,6 +20,13 @@
  * in every action interval. Also is able to release multiple types of molecules.
  * - added simpler methods for defining region anchor coordinates and the number of
  * subvolumes along each dimension of rectangular regions.
+ * - added local diffusion coefficients as region parameters. Any region can
+ * over-ride the default diffusion coefficients defined for all molecules
+ * - added specifying diffusion coefficient to use for surface reaction transition
+ * probabilities. By default, the reactant's default diffusion coefficient is used
+ * for absorption and membrane reactions, and the first product's default diffusion
+ * coefficient is used for desorption reactions. Warning appears if coefficient is
+ * defined for reaction types that cannot use it.
  *
  * Revision v0.7.0.1 (public beta, 2016-08-30)
  * - added measurement of simulation runtime to be written to simulation output

--- a/src/micro_molecule.c
+++ b/src/micro_molecule.c
@@ -10,9 +10,13 @@
  * micro_molecule.c - 	linked list of individual molecules in same
  * 						microscopic region
  *
- * Last revised for AcCoRD v0.7 (public beta, 2016-07-09)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added specifying diffusion coefficient that applies to specific surface
+ * interaction reactions.
  *
  * Revision v0.7 (public beta, 2016-07-09)
  * - set microscopic partial time step to 0 when creating new molecule from meso
@@ -798,7 +802,7 @@ void rxnFirstOrderRecent(const unsigned short NUM_REGIONS,
 			calculateDesorptionProb(&curProb, curRegion, curMolType,
 				regionArray[curRegion].rxnOutID[curMolType],
 				curNode->item.dt_partial, NUM_REGIONS,
-				regionArray, NUM_MOL_TYPES, DIFF_COEF);
+				regionArray, NUM_MOL_TYPES);
 			curRand = generateUniform();
 			if(curRand < curProb)
 			{				
@@ -1863,8 +1867,7 @@ bool followMolecule(const double startPoint[3],
 								// Need to calculate absorption probability
 								rxnProb = calculateAbsorptionProb(*endRegion,
 									molType, *curRxn,
-									dt, NUM_REGIONS, regionArray, NUM_MOL_TYPES,
-									DIFF_COEF);
+									dt, NUM_REGIONS, regionArray, NUM_MOL_TYPES);
 							} else
 							{ // Use pre-calculated probability
 								rxnProb = regionArray[*endRegion].surfRxnInProb[molType];
@@ -1888,8 +1891,7 @@ bool followMolecule(const double startPoint[3],
 									if(bRecent)
 										rxnProb = calculateMembraneProb(*endRegion,
 											molType, *curRxn,
-											dt, NUM_REGIONS, regionArray, NUM_MOL_TYPES,
-											DIFF_COEF);
+											dt, NUM_REGIONS, regionArray, NUM_MOL_TYPES);
 									else
 										rxnProb = regionArray[*endRegion].surfRxnInProb[molType];
 								} else
@@ -1903,8 +1905,7 @@ bool followMolecule(const double startPoint[3],
 									if(bRecent)
 										rxnProb = calculateMembraneProb(*endRegion,
 											molType, *curRxn,
-											dt, NUM_REGIONS, regionArray, NUM_MOL_TYPES,
-											DIFF_COEF);
+											dt, NUM_REGIONS, regionArray, NUM_MOL_TYPES);
 									else
 										rxnProb = regionArray[*endRegion].surfRxnOutProb[molType];
 								} else

--- a/src/micro_molecule.h
+++ b/src/micro_molecule.h
@@ -10,9 +10,13 @@
  * micro_molecule.h - 	linked list of individual molecules in same
  * 						microscopic region
  *
- * Last revised for AcCoRD v0.7 (public beta, 2016-07-09)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added specifying diffusion coefficient that applies to specific surface
+ * interaction reactions.
  *
  * Revision v0.7 (public beta, 2016-07-09)
  * - set microscopic partial time step to 0 when creating new molecule from meso

--- a/src/region.c
+++ b/src/region.c
@@ -10,9 +10,14 @@
  * region.c - 	operations for (microscopic or mesoscopic) regions in
  * 				simulation environment
  *
- * Last revised for AcCoRD v0.7.0.1 (public beta, 2016-08-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added local diffusion coefficients that can apply to particular region
+ * - added specifying diffusion coefficient that applies to specific surface
+ * interaction reactions.
  *
  * Revision v0.7.0.1 (public beta, 2016-08-30)
  * - corrected calculating region volume when a normal region has a surface child

--- a/src/region.h
+++ b/src/region.h
@@ -10,9 +10,14 @@
  * region.h - 	operations for (microscopic or mesoscopic) regions in
  * 				simulation environment
  *
- * Last revised for AcCoRD v0.7.0.1 (public beta, 2016-08-30)
+ * Last revised for AcCoRD LATEST_VERSION
  *
  * Revision history:
+ *
+ * Revision LATEST_VERSION
+ * - added local diffusion coefficients that can apply to particular region
+ * - added specifying diffusion coefficient that applies to specific surface
+ * interaction reactions.
  *
  * Revision v0.7.0.1 (public beta, 2016-08-30)
  * - corrected calculating region volume when a normal region has a surface child
@@ -98,6 +103,12 @@ struct spec_region3D { // Used to define a region of subvolumes
 	
 	// Is the region microscopic?
 	bool bMicro;
+	
+	// Does this region use different diffusion coefficients?
+	bool bLocalDiffusion;
+	
+	// Local diffusion coefficients (if applicable)
+	double * diffusion;
 	
 	// Region shape. There are specific restrictions on shape, depending on
 	// whether it is micro, whether its parent is micro, and whether it is
@@ -446,6 +457,10 @@ struct region { // Region boundary parameters
 	// Default is RXN_PROB_NORMAL, which is inaccurate for surface transition reactions
 	// Length numChemRxn
 	short * rxnProbType;
+	
+	// Diffusion coefficient used for surface reaction probability calculation
+	// Length numChemRxn
+	double * rxnDiffCoef;
 	
 	// Does an absorbing or membrane reaction exist for a given molecule?
 	// Membrane reaction is for passing from the "inner" direction


### PR DESCRIPTION
- regions can have locally-defined diffusion coefficients that over-ride the default values for each molecule type
- diffusion coefficient used for surface reactions can be specified to over-ride the default coefficient for the corresponding type of molecule
- updated parameter import in Matlab to accommodate local diffusion and the new syntax for defining regions
