### PR TITLE
Fix generation of product molecules in replication reactions

### DIFF
--- a/src/accord.c
+++ b/src/accord.c
@@ -15,6 +15,8 @@
  *
  * Revision LATEST_RELEASE
  * - corrected limit on the number of actions made by passive actors
+ * - fixed typo in comment describing implementation of reactions for "new"
+ * microscopic molecules (created in current time step)
  *
  * Revision v1.1 (2016-12-24)
  * - added direction of subvolume neighbors as a standalone 2D array in order
@@ -811,7 +813,7 @@ int main(int argc, char *argv[])
 						
 							if(!isListMol3DRecentEmpty(&microMolListRecent[i][j])
 								&& regionArray[i].numFirstRxnWithReactant[j] > 0)
-							{ // Check 1st order reactions of "old" molecules
+							{ // Check 1st order reactions of "new" molecules
 								rxnFirstOrderRecent(spec.NUM_REGIONS,
 									spec.NUM_MOL_TYPES, i, microMolListRecent,
 									microMolList, regionArray, j, DIFF_COEF,

--- a/src/micro_molecule.h
+++ b/src/micro_molecule.h
@@ -10,9 +10,14 @@
  * micro_molecule.h - 	linked list of individual molecules in same
  * 						microscopic region
  *
- * Last revised for AcCoRD v1.1 (2016-12-24)
+ * Last revised for AcCoRD LATEST_RELEASE
  *
  * Revision history:
+ *
+ * Revision LATEST_RELEASE
+ * - fixed implementation of replication reactions, where a first order reactant produces
+ * at least one copy of itself. If such a reactant reacted again within the same
+ * microscopic time step, then the new molecule(s) previously went missing.
  *
  * Revision v1.1 (2016-12-24)
  * - simplified detection of whether molecules flow or diffuse in each region
@@ -240,7 +245,8 @@ void rxnFirstOrderProductPlacement(const NodeMol3D * curMol,
 	const struct region regionArray[],
 	unsigned short curMolType,	
 	double DIFF_COEF[NUM_REGIONS][NUM_MOL_TYPES],
-	const bool bRecent);
+	const bool bRecent,
+	bool * bProductIsReactant);
 
 // If a molecule is the product of a surface reaction and it is supposed
 // to be released from the surface, find the destination region


### PR DESCRIPTION
- modified implementation of first order reactions to catch cases where a "new" microscopic reactant replicates within the same time step that it was created. Previously, these molecules went missing. Now, they should be identified properly within the updated list of microscopic molecules.