### PR TITLE
Video bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ matlab/impulse*
 matlab/meso*
 matlab/noel*
 matlab/point*
+matlab_*

--- a/matlab/accordPlotSingleObservation.m
+++ b/matlab/accordPlotSingleObservation.m
@@ -29,9 +29,13 @@ function hPoints = accordPlotSingleObservation(hAxes, data, actorInd, molStruct,
 % OUTPUTS
 % hPoints - cell array of handles to plots made at this observation point
 %
-% Last revised for AcCoRD v1.2 (2018-05-30)
+% Last revised for AcCoRD LATEST_VERSION
 %
 % Revision history:
+%
+% Revision LATEST_VERSION
+% - corrected indexing of plots where markers are used to draw the
+% molecules
 %
 % Revision v1.2 (2018-05-30)
 % - added plotting molecules as shapes instead of only as markers. Added
@@ -59,12 +63,12 @@ for i = 1:molStruct.numToDisp
                     scatter3(hAxes, scale*data.passiveRecordPos{actorInd}{curMol}{realization,obsInd}(:,1),...
                     scale*data.passiveRecordPos{actorInd}{curMol}{realization,obsInd}(:,2),...
                     scale*data.passiveRecordPos{actorInd}{curMol}{realization,obsInd}(:,3));
-                set(hPoints(i),'DisplayName', molStruct.dispStr{1}{i});
-                set(hPoints(i),'SizeData', molStruct.size(i));
-                set(hPoints(i),'LineWidth', molStruct.lineWidth(i));
-                set(hPoints(i),'MarkerEdgeColor', molStruct.edgeColor{1}{i});
-                set(hPoints(i),'MarkerFaceColor', molStruct.faceColor{1}{i});
-                set(hPoints(i),'Marker', molStruct.marker{1}{i});
+                set(hPoints{i},'DisplayName', molStruct.dispStr{1}{i});
+                set(hPoints{i},'SizeData', molStruct.size(i));
+                set(hPoints{i},'LineWidth', molStruct.lineWidth(i));
+                set(hPoints{i},'MarkerEdgeColor', molStruct.edgeColor{1}{i});
+                set(hPoints{i},'MarkerFaceColor', molStruct.faceColor{1}{i});
+                set(hPoints{i},'Marker', molStruct.marker{1}{i});
             case 'sphere'
                 % Plot each molecule as an individual 3D sphere
                 numMol = data.passiveRecordCount{actorInd}(realization,curMol,obsInd);

--- a/matlab/accordVideoMaker.m
+++ b/matlab/accordVideoMaker.m
@@ -95,9 +95,13 @@ function [hFig, hAxes] = accordVideoMaker(fileToLoad,...
 % hFig - handle(s) to plotted figure(s). Use for making changes.
 % hAxes - handle(s) to axes in plotted figure(s). Use for making changes.
 %
-% Last revised for AcCoRD v1.2 (2018-05-30)
+% Last revised for AcCoRD LATEST_VERSION
 %
 % Revision history:
+%
+% Revision LATEST_VERSION
+% - added initialisation of nested function variables that can be read
+% globally. Needed for code to execute as of R2019b.
 %
 % Revision v1.2 (2018-05-30)
 % - updated call to build function for plotting molecules to accommodate
@@ -126,6 +130,13 @@ function [hFig, hAxes] = accordVideoMaker(fileToLoad,...
 
 %% Load Simulation Output
 load(fileToLoad, 'config', 'data');
+
+%% Code for R2019b - need to define nested function variables that have external scope
+hTimer = [];
+tArray = [];
+hObsCount = [];
+counterArray = [];
+counterText = [];
 
 %% Confirm Size of Molecule Arrays
 numFrames = length(observationToPlot);


### PR DESCRIPTION
R2019b of MATLAB removed option for variables defined only inside subfunctions to have external scope. This broke the video maker as certain variables were only created when adding particular video features at run time. Code was updated to address this with no front-end changes.

Also fixed bug when trying to plot molecules that are defined as points.